### PR TITLE
feat(pwa): manifest + service worker + auto update

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,12 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Testare la PWA
+
+Per verificare il funzionamento della PWA in locale:
+
+1. Installa le dipendenze con `npm install`.
+2. Esegui la build di produzione: `npm run build`.
+3. Avvia l'anteprima locale: `npm run preview` e apri l'URL mostrato.
+4. Da browser, usa "Aggiungi alla schermata Home" e verifica che compaia il toast "App aggiornata — ricarica" quando è disponibile un aggiornamento.

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,20 @@
+{
+  "name": "EZYSTAFF",
+  "short_name": "EZYSTAFF",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#52a594",
+  "icons": [
+    {
+      "src": "/pwa-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/pwa-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,13 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import { registerSW } from 'virtual:pwa-register'
+import { toast } from '@/hooks/use-toast'
 
-createRoot(document.getElementById("root")!).render(<App />);
+registerSW({
+  onNeedRefresh() {
+    toast({ title: 'App aggiornata — ricarica' })
+  },
+})
+
+createRoot(document.getElementById('root')!).render(<App />);


### PR DESCRIPTION
## Summary
- registra SW con auto update e toast
- aggiunge manifest e guida per testare la PWA

## Testing
- `npm run build`
- `npm test` (missing script)


------
https://chatgpt.com/codex/tasks/task_e_68c7dacd1614832ebb157f76a03facad